### PR TITLE
Fix #14: ArgoUML does not compile with Java8 or Java 11, small adaptations

### DIFF
--- a/src/argouml-app/src/org/argouml/cognitive/ListSet.java
+++ b/src/argouml-app/src/org/argouml/cognitive/ListSet.java
@@ -48,32 +48,33 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
+import java.util.Spliterator;
 
 /**
  * An Ordered, non-duplicated collection of objects (not exactly a
  * mathematical set because it is ordered).
- * 
+ *
  * @param <T> The type of objects this ListSet is to contain.
  */
-public class ListSet<T extends Object> 
+public class ListSet<T>
     implements Serializable, Set<T>, List<T> {
 
     private static final int TC_LIMIT = 50;
 
     private List<T> list;
-    
+
     /**
      * A hash set containing the same items as the list so that we can
-     * use it for fast lookups.  
+     * use it for fast lookups.
      */
     private Set<T> set;
-    
+
     /**
      * The mutex/lock which is used for operations that need to check/modify
      * both the set and list.  Get operations which only access the list can
      * rely on the fact that it is a synchronized list.
      */
-    private final Object mutex = new Object(); 
+    private final Object mutex = new Object();
 
     /**
      * The constructor.
@@ -104,6 +105,10 @@ public class ListSet<T extends Object>
         add(o1);
     }
 
+    @Override
+    public Spliterator<T> spliterator() {
+        return List.super.spliterator();
+    }
 
     /**
      * @param iter an enumeration of objects to be added
@@ -128,7 +133,7 @@ public class ListSet<T extends Object>
      * @param iter an iterator of objects to be added
      * @param p the predicate the objects have to fulfill to be added
      */
-    public void addAllElementsSuchThat(Iterator<T> iter, 
+    public void addAllElementsSuchThat(Iterator<T> iter,
     		org.argouml.util.Predicate p) {
         if (p instanceof org.argouml.util.PredicateTrue) {
             addAllElements(iter);
@@ -147,13 +152,13 @@ public class ListSet<T extends Object>
      * @param s a listset of objects to be added
      * @param p the predicate the objects have to fulfill to be added
      */
-    public void addAllElementsSuchThat(ListSet<T> s, 
+    public void addAllElementsSuchThat(ListSet<T> s,
     		org.argouml.util.Predicate p) {
         synchronized (s.mutex()) {
             addAllElementsSuchThat(s.iterator(), p);
         }
     }
-    
+
     /*
      * @see java.util.Collection#remove(java.lang.Object)
      */
@@ -203,9 +208,9 @@ public class ListSet<T extends Object>
      */
     public boolean containsSuchThat(org.argouml.util.Predicate p) {
         return findSuchThat(p) != null;
-    }    
+    }
 
-    
+
     /**
      * Return the first object that causes the given predicate to return
      * true.
@@ -267,7 +272,7 @@ public class ListSet<T extends Object>
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("Set{");  
+        StringBuilder sb = new StringBuilder("Set{");
         synchronized (list) {
             for (Iterator it = iterator(); it.hasNext();) {
                 sb.append(it.next());
@@ -287,12 +292,12 @@ public class ListSet<T extends Object>
      * the elements of the original Set. In order to avoid very deep searches
      * which are often programming mistakes, only paths of length TC_LIMIT or
      * less are considered.
-     * 
+     *
      * @param cg the given childgenerator
      * @return the resulting listset
      */
     public ListSet<T> transitiveClosure(org.argouml.util.ChildGenerator cg) {
-        return transitiveClosure(cg, TC_LIMIT, 
+        return transitiveClosure(cg, TC_LIMIT,
         		org.argouml.util.PredicateTrue.getInstance());
     }
 
@@ -302,12 +307,12 @@ public class ListSet<T extends Object>
      * include the elements of the original Set. In order to avoid very deep
      * searches which are often programming mistakes, only paths of length
      * TC_LIMIT or less are considered.
-     * 
+     *
      * @param cg the given childgenerator
      * @return the resulting listset
      */
     public ListSet<T> reachable(org.argouml.util.ChildGenerator cg) {
-        return reachable(cg, TC_LIMIT, 
+        return reachable(cg, TC_LIMIT,
         		org.argouml.util.PredicateTrue.getInstance());
     }
 
@@ -319,13 +324,13 @@ public class ListSet<T extends Object>
      * searches which are often programming mistakes, only paths of given max
      * length or less are considered. Only paths consisting of elements which
      * all cause predicate.evaluate() to return true are considered.
-     * 
+     *
      * @param cg the given childgenerator
      * @param max the maximum depth
      * @param predicate the predicate the objects have to fulfill
      * @return the resulting listset
      */
-    public ListSet<T> reachable(org.argouml.util.ChildGenerator cg, int max, 
+    public ListSet<T> reachable(org.argouml.util.ChildGenerator cg, int max,
     		org.argouml.util.Predicate predicate) {
         ListSet<T> kids = new ListSet<T>();
         synchronized (list) {
@@ -345,7 +350,7 @@ public class ListSet<T extends Object>
      * which are often programming mistakes, only paths of given max length or
      * less are considered. Only paths consisting of elements which all cause
      * predicate.evaluate() to return true are considered.
-     * 
+     *
      * @param cg the given childgenerator
      * @param max the maximum depth
      * @param predicate the predicate the objects have to fulfill
@@ -367,7 +372,7 @@ public class ListSet<T extends Object>
             synchronized (recent) {
                 for (T recentElement : recent) {
                     Iterator frontierChildren = cg.childIterator(recentElement);
-                    frontier.addAllElementsSuchThat(frontierChildren, 
+                    frontier.addAllElementsSuchThat(frontierChildren,
                             predicate);
                 }
             }
@@ -376,7 +381,7 @@ public class ListSet<T extends Object>
         }
         return touched;
     }
-    
+
     /*
      * @see java.util.Collection#isEmpty()
      */
@@ -390,7 +395,7 @@ public class ListSet<T extends Object>
     public Iterator<T> iterator() {
         return list.iterator();
     }
-    
+
     /**
      * @return mutex object to synchronize on for iteration
      */

--- a/src/argouml-app/src/org/argouml/uml/ui/UMLModelElementListModel2.java
+++ b/src/argouml-app/src/org/argouml/uml/ui/UMLModelElementListModel2.java
@@ -293,7 +293,7 @@ public abstract class UMLModelElementListModel2 extends DefaultListModel
      * Utility method to add a collection of elements to the model
      * @param col the given collection
      */
-    protected void addAll(Collection col) {
+    public void addAll(Collection col) {
         if (col.size() == 0) {
             return;
         }

--- a/src/argouml-app/src/org/argouml/uml/ui/UMLStereotypeListModel.java
+++ b/src/argouml-app/src/org/argouml/uml/ui/UMLStereotypeListModel.java
@@ -290,7 +290,7 @@ abstract class UMLStereotypeListModel extends DefaultListModel
      * Utility method to add a collection of elements to the model
      * @param col the given collection
      */
-    protected void addAll(Collection col) {
+    public void addAll(Collection col) {
         if (col.size() == 0) {
             return;
         }

--- a/src/argouml-core-umlpropertypanels/src/org/argouml/core/propertypanels/ui/UMLModelElementListModel.java
+++ b/src/argouml-core-umlpropertypanels/src/org/argouml/core/propertypanels/ui/UMLModelElementListModel.java
@@ -465,7 +465,7 @@ abstract class UMLModelElementListModel
      * Utility method to add a collection of elements to the model
      * @param col the given collection
      */
-    protected void addAll(Collection col) {
+    public void addAll(Collection col) {
         if (col.size() == 0) return;
         Iterator it = col.iterator();
         fireListEvents = false;


### PR DESCRIPTION
Fix the ListSet class to use the Spliterator so that it compiles with Java 8.
Fix classes that inherit from DefaultListModel to make the addAll() public
instead of protected.

Change-Id: I91836a692dbc6125540502e6c96d87016a827bde