### PR TITLE
Fix #16: ArgoUML tries to download http://argouml.org/profiles/uml14/default-uml14.xmi

### DIFF
--- a/src/argouml-core-model-mdr/src/org/argouml/model/mdr/MDRModelImplementation.java
+++ b/src/argouml-core-model-mdr/src/org/argouml/model/mdr/MDRModelImplementation.java
@@ -39,6 +39,7 @@
 package org.argouml.model.mdr;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.util.ArrayList;
@@ -102,6 +103,7 @@ import org.netbeans.api.mdr.MDRepository;
 import org.netbeans.api.xmi.XMIReader;
 import org.netbeans.api.xmi.XMIReaderFactory;
 import org.omg.uml.UmlPackage;
+import org.xml.sax.InputSource;
 
 /**
  * The handle to find all helper and factories.
@@ -502,6 +504,36 @@ public class MDRModelImplementation implements ModelImplementation {
                 break;
             }
         }
+    }
+
+    static String PROFILES_RESOURCE_PATH =
+        "/org/argouml/profile/profiles/uml14/";
+
+    static String PROFILES_BASE_URL =
+        "http://argouml.org/profiles/uml14/";
+
+    /**
+     * Open the URL to read the model file.  We try to avoid connecting
+     * to the remote peer by looking at the model file locally.
+     * In most cases, the model file is located at PROFILES_BASE_URL
+     * (http://argouml.org) which might be defunct at some point in the future.
+     *
+     * @param url the URL to open.
+     * @return the input stream.
+     */
+    InputSource getInputSource(URL url) {
+        String uri = url.toExternalForm();
+        if (uri.startsWith(PROFILES_BASE_URL)) {
+            String name = uri.substring(PROFILES_BASE_URL.length());
+            InputStream inputStream = getClass().getResourceAsStream(PROFILES_RESOURCE_PATH + name);
+            return new InputSource(inputStream);
+        }
+
+        // Note: we could have more rules here such as to look at
+        // some specific local places.  If the uri is a file localtion,
+        // everthing is ok.  There is still the issue with user profiles
+        // that will be downloaded from http://argouml.org...
+        return new InputSource(uri);
     }
 
     /**

--- a/src/argouml-core-model-mdr/src/org/argouml/model/mdr/XmiReferenceResolverImpl.java
+++ b/src/argouml-core-model-mdr/src/org/argouml/model/mdr/XmiReferenceResolverImpl.java
@@ -326,7 +326,11 @@ class XmiReferenceResolverImpl extends XmiContext {
      * @return map of xmi.id to RefObject correspondences
      */
     Map<String, Object> getIdToObjectMap() {
-        return getIdToObjectMaps().get(topSystemId);
+        if (idToObject != null) {
+            return idToObject.get(topSystemId);
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -340,7 +344,10 @@ class XmiReferenceResolverImpl extends XmiContext {
      * Reinitialize the object id maps to the empty state.
      */
     void clearIdMaps() {
-        getIdToObjectMap().clear();
+        Map<String, Object> map = getIdToObjectMap();
+        if (map != null) {
+            map.clear();
+        }
         mofidToXmiref.clear();
         topSystemId = null;
     }
@@ -629,7 +636,7 @@ class XmiReferenceResolverImpl extends XmiContext {
         // We've got a profile read pending - handle it ourselves now
         URL url = pendingProfiles.remove(arg0);
         if (url != null) {
-            InputSource is = new InputSource(url.toExternalForm());
+            InputSource is = modelImpl.getInputSource(url);
             is.setPublicId(arg0);
             XmiReaderImpl reader = new XmiReaderImpl(modelImpl);
             try {


### PR DESCRIPTION
Add getInputSource() in MDRModelImplementation to open a model URI and look
locally if we know the file to avoid getting it from the http://argouml.org site
which may be defunct in some future.

When we open a model, use the modelImpl getInputSource() to get the input
stream that gives access to its content.

Fix crash in getIdToObjectMap() and clearIdMaps() when there is a problem
loading some model.

Change-Id: Ib2c04aab5f6e397f274658e37efcf45ca6c43ed6