### PR TITLE
Fix #18: ArgoUML crash when it fails to get the Argo.ARGOINI file or when there are no extensions

### DIFF
--- a/src/argouml-app/src/org/argouml/moduleloader/ModuleLoader2.java
+++ b/src/argouml-app/src/org/argouml/moduleloader/ModuleLoader2.java
@@ -492,7 +492,12 @@ public final class ModuleLoader2 {
     private void computeExtensionLocations() {
         // Use a little trick to find out where Argo is being loaded from.
         // TODO: Use a different resource here. ARGOINI is unused and deprecated
-        String extForm = getClass().getResource(Argo.ARGOINI).toExternalForm();
+        URL extURL = getClass().getResource(Argo.ARGOINI);
+        if (extURL == null) {
+            LOG.log(Level.SEVERE, "cannot find {0}", Argo.ARGOINI);
+            return;
+        }
+        String extForm = extURL.toExternalForm();
         String argoRoot =
             extForm.substring(0,
                               extForm.length() - Argo.ARGOINI.length());

--- a/src/argouml-app/src/org/argouml/moduleloader/SettingsTabModules.java
+++ b/src/argouml-app/src/org/argouml/moduleloader/SettingsTabModules.java
@@ -68,14 +68,14 @@ class SettingsTabModules extends JPanel
      * The table of modules.
      */
     private JTable table;
-    
+
     private JTextField fieldAllExtDirs;
 
     /**
      * The names of the columns in the table.
      */
     private String[] columnNames = {
-	Translator.localize("misc.column-name.module"), 
+	Translator.localize("misc.column-name.module"),
         Translator.localize("misc.column-name.enabled"),
     };
 
@@ -140,7 +140,7 @@ class SettingsTabModules extends JPanel
 	    if (row < elements.length) {
 		return elements[row][col];
 	    } else {
-	        return null;       
+	        return null;
             }
 	}
 
@@ -184,14 +184,16 @@ class SettingsTabModules extends JPanel
      */
     public void handleSettingsTabRefresh() {
         table.setModel(new ModuleTableModel());
-        
+
         StringBuffer sb = new StringBuffer();
         List locations = ModuleLoader2.getInstance().getExtensionLocations();
         for (Iterator it = locations.iterator(); it.hasNext();) {
             sb.append((String) it.next());
             sb.append("\n");
         }
-        fieldAllExtDirs.setText(sb.substring(0, sb.length() - 1).toString());
+        if (sb.length() > 0) {
+            fieldAllExtDirs.setText(sb.substring(0, sb.length() - 1).toString());
+        }
     }
 
     /*


### PR DESCRIPTION
In computeExtensionLocations(), if we fail to load the .argoini,
don't abort and don't crash.

In handleSettingsTabRefresh(), check that the sb buffer has some content before
stripping a part of it.

Change-Id: I58bbb33c8f55431426a1017541aadfd1bf50e875