### PR TITLE
Fix #20: Maven plugin to create a self contained ArgoUML jar file

### DIFF
--- a/src/argouml-build/pom.xml
+++ b/src/argouml-build/pom.xml
@@ -97,6 +97,73 @@
     <developerConnection>scm:git:${gerrithub.site.org.ssh}/${github.site.repositoryName}.git</developerConnection>
   </scm>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <version>2.10</version>
+                <configuration>
+                    <downloadSources>true</downloadSources>
+                    <downloadJavadocs>true</downloadJavadocs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+<!--                <artifactId>maven-jar-plugin</artifactId> -->
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+
+                    <execution>
+                        <id>argouml</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <finalName>argouml</finalName>
+                            <includes>
+                                <include>**/*</include>
+                            </includes>
+                            <descriptorRefs>
+                                  <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <archive>
+                                <manifestEntries>
+                                    <Built-By>${company.name}</Built-By>
+                                </manifestEntries>
+                                <manifest>
+                                    <mainClass>org.argouml.application.Main</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
   <profiles>
     <profile>
       <id>mdr</id>


### PR DESCRIPTION
Use the maven-assembly-plugin to create a single jar with dependencies
that we can use to distribute and launch ArgoUML.  Usage is:

java -jar argouml-jar-with-dependencies.jar

Change-Id: I9c91d156123b116965d0378a3297968d6587d92e