### PR TITLE
Fix #22: ArgoUML crash when a UML notation provider is not found

### DIFF
--- a/src/argouml-app/src/org/argouml/notation/NotationProviderFactory2.java
+++ b/src/argouml-app/src/org/argouml/notation/NotationProviderFactory2.java
@@ -258,6 +258,7 @@ public final class NotationProviderFactory2 {
                 LOG.log(Level.SEVERE, "Exception caught", e);
             }
         }
+        LOG.log(Level.SEVERE, "No notation provider for " + name + " type " + type);
         return null;
     }
 
@@ -279,8 +280,10 @@ public final class NotationProviderFactory2 {
             NotationName name) {
 
         NotationProvider p = getNotationProvider(type, object, name);
-        p.setRenderer(nr);
-        p.initialiseListener(object);
+        if (p != null) {
+            p.setRenderer(nr);
+            p.initialiseListener(object);
+        }
         return p;
     }
 


### PR DESCRIPTION
In getNotationProvider(), add an error message if we fail to find the notation provider
and check that it did not return null when using it so that we avoid a crash.

Change-Id: Iccd1d46727750a17517b028c70127164e709aa3a