### PR TITLE
Fix #24: ArgoUML should use batik 1.13

### DIFF
--- a/src/argouml-app/pom.xml
+++ b/src/argouml-app/pom.xml
@@ -41,37 +41,37 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.batik</groupId>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-dom</artifactId>
-      <version>1.7</version>
+      <version>1.13</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.batik</groupId>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-util</artifactId>
-      <version>1.7</version>
+      <version>1.13</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.batik</groupId>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-ext</artifactId>
-      <version>1.7</version>
+      <version>1.13</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.batik</groupId>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-svggen</artifactId>
-      <version>1.7</version>
+      <version>1.13</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.batik</groupId>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-awt-util</artifactId>
-      <version>1.7</version>
+      <version>1.13</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
Use org.apache.xmlgraphics for the groupId to use batik
and switch to version 1.13.

Change-Id: Ifeb6d4b5fe45565110991cd0e1b0e664269f8775