### PR TITLE
Fix #26: Add system property option to configure a default UML profile directory

### DIFF
--- a/src/argouml-app/src/org/argouml/profile/internal/ProfileManagerImpl.java
+++ b/src/argouml-app/src/org/argouml/profile/internal/ProfileManagerImpl.java
@@ -254,6 +254,12 @@ public class ProfileManagerImpl implements ProfileManager {
         while (tokenizer.hasMoreTokens()) {
             searchDirectories.add(tokenizer.nextToken());
         }
+
+        // Add an optional default configured from system options.
+        String def = System.getProperty("argouml.profiles.directory");
+        if (def != null && def.length() > 0 && !searchDirectories.contains(def)) {
+            searchDirectories.add(def);
+        }
         disableConfigurationUpdate = false;
     }
 


### PR DESCRIPTION
In loadDirectoriesFromConfiguration, look at the 'argouml.properties.directory' system
property to setup a defaul search directory for UML profiles.

Change-Id: I3d055ebd868c2e24446dd365c1a4e3f7232d9b34